### PR TITLE
Update testnet.snippets.sh

### DIFF
--- a/contracts/adder/interaction/testnet.snippets.sh
+++ b/contracts/adder/interaction/testnet.snippets.sh
@@ -4,7 +4,7 @@ DEPLOY_TRANSACTION=$(mxpy data load --key=deployTransaction-testnet)
 PROXY=https://testnet-api.multiversx.com
 
 deploy() {
-    mxpy --verbose contract deploy --project=${PROJECT} --recall-nonce --pem=${ALICE} --gas-limit=50000000 --arguments 0 --send --outfile="deploy-testnet.interaction.json" --proxy=${PROXY} --chain=T || return
+    mxpy contract deploy --project=${PROJECT} --recall-nonce --pem=${ALICE} --gas-limit=50000000 --arguments 0 --send --outfile="deploy-testnet.interaction.json" --proxy=${PROXY} --chain=T || return
 
     TRANSACTION=$(mxpy data parse --file="deploy-testnet.interaction.json" --expression="data['emittedTransactionHash']")
     ADDRESS=$(mxpy data parse --file="deploy-testnet.interaction.json" --expression="data['contractAddress']")
@@ -18,9 +18,9 @@ deploy() {
 
 add() {
     read -p "Enter number: " NUMBER
-    mxpy --verbose contract call ${ADDRESS} --recall-nonce --pem=${ALICE} --gas-limit=5000000 --function="add" --arguments ${NUMBER} --send --proxy=${PROXY} --chain=T
+    mxpy contract call ${ADDRESS} --recall-nonce --pem=${ALICE} --gas-limit=5000000 --function="add" --arguments ${NUMBER} --send --proxy=${PROXY} --chain=T
 }
 
 getSum() {
-    mxpy --verbose contract query ${ADDRESS} --function="getSum" --proxy=${PROXY}
+    mxpy contract query ${ADDRESS} --function="getSum" --proxy=${PROXY}
 }

--- a/contracts/adder/interaction/testnet.snippets.sh
+++ b/contracts/adder/interaction/testnet.snippets.sh
@@ -4,7 +4,7 @@ DEPLOY_TRANSACTION=$(mxpy data load --key=deployTransaction-testnet)
 PROXY=https://testnet-api.multiversx.com
 
 deploy() {
-    mxpy contract deploy --project=${PROJECT} --recall-nonce --pem=${ALICE} --gas-limit=50000000 --arguments 0 --send --outfile="deploy-testnet.interaction.json" --proxy=${PROXY} --chain=T || return
+    mxpy contract deploy --bytecode=${PROJECT} --recall-nonce --pem=${ALICE} --gas-limit=50000000 --arguments 0 --send --outfile="deploy-testnet.interaction.json" --proxy=${PROXY} --chain=T || return
 
     TRANSACTION=$(mxpy data parse --file="deploy-testnet.interaction.json" --expression="data['emittedTransactionHash']")
     ADDRESS=$(mxpy data parse --file="deploy-testnet.interaction.json" --expression="data['contractAddress']")


### PR DESCRIPTION
Deleted --verbose argument out of mxpy commands, as it is indeed a good way of seeing what's happening behind the commands, but it is also filling the variables with logger information that is destructing the flow of the deployment.

example: --verbose on mxpy contract call is filling ${ADDRESS} with a logger.warning() message before filling it with the actual address.

2nd Commit: Added --bytecode instead of --project.